### PR TITLE
Load and save (for missions)

### DIFF
--- a/_includes/missions/section-actions.html
+++ b/_includes/missions/section-actions.html
@@ -1,39 +1,48 @@
-<div class="card-body" style="margin-bottom:100px">
-
-  <div class="mt-4">
-    <div class="btn-group" role="group">
-      <button class="btn btn-success" id="saveCanvasButton" onclick="onExportToImage()">
-        Export image
+<div class="card" style="margin-bottom:100px">
+  <div class="card-header" id="missionsHeadingActions">
+    <h2 class="h5 mb-0">
+      <button class="btn btn-link" data-toggle="collapse" data-target="#missionsCollapseActions"
+              aria-expanded="false" aria-controls="missionsCollapseActions">
+        Load / Save / Export
       </button>
-      <button class="btn btn-success" id="saveButton" onclick="onExportToFile()">
-        Export file
-      </button>
-      <label for="loadbutton" class="btn btn-success" style="margin-bottom:0">
-        Import file
-        <input class="form-control-file" id="loadbutton" oninput="fileChange(this.files[0])" type="file" style="display:none">
-      </label>
-      <button class="btn btn-warning" id="clearCacheButton" onclick="onResetToDefault()">
-        Reset
-      </button>
-    </div>
+    </h2>
   </div>
-
-  <div class="mt-4">
-    <div class="btn-group" role="group">
-      <button class="btn btn-success" onclick="onSaveSlot()">
-        Save
-      </button>
-      <button class="btn btn-success" onclick="onLoadSlot()">
-        Load
-      </button>
-      <button class="btn btn-warning" onclick="onDeleteSlot()">
-        Delete
-      </button>
+  <div id="missionsCollapseActions" class="card-body collapse show">
+    <div class="mt-4">
+      <div class="btn-group" role="group">
+        <button class="btn btn-success" id="saveCanvasButton" onclick="onExportToImage()">
+          Export image
+        </button>
+        <button class="btn btn-success" id="saveButton" onclick="onExportToFile()">
+          Export file
+        </button>
+        <label for="loadbutton" class="btn btn-success" style="margin-bottom:0">
+          Import file
+          <input class="form-control-file" id="loadbutton" oninput="fileChange(this.files[0])" type="file" style="display:none">
+        </label>
+        <button class="btn btn-warning" id="clearCacheButton" onclick="onResetToDefault()">
+          Reset
+        </button>
+      </div>
     </div>
-  </div>
 
-  <div class="mt-4">
-    <select size="8" class="form-control" id="slotList">
-    </select>
+    <div class="mt-4">
+      <div class="btn-group" role="group">
+        <button class="btn btn-success" onclick="onSaveSlot()">
+          Save
+        </button>
+        <button class="btn btn-success" onclick="onLoadSlot()">
+          Load
+        </button>
+        <button class="btn btn-warning" onclick="onDeleteSlot()">
+          Delete
+        </button>
+      </div>
+    </div>
+
+    <div class="mt-4">
+      <select size="8" class="form-control" id="slotList">
+      </select>
+    </div>
   </div>
 </div>

--- a/_includes/missions/section-actions.html
+++ b/_includes/missions/section-actions.html
@@ -1,49 +1,39 @@
-<div class="form-group">
-    
+<div class="card-body" style="margin-bottom:100px">
+
+  <div class="mt-4">
+    <div class="btn-group" role="group">
+      <button class="btn btn-success" id="saveCanvasButton" onclick="onExportToImage()">
+        Export image
+      </button>
+      <button class="btn btn-success" id="saveButton" onclick="onExportToFile()">
+        Export file
+      </button>
+      <label for="loadbutton" class="btn btn-success" style="margin-bottom:0">
+        Import file
+        <input class="form-control-file" id="loadbutton" oninput="fileChange(this.files[0])" type="file" style="display:none">
+      </label>
+      <button class="btn btn-warning" id="clearCacheButton" onclick="onResetToDefault()">
+        Reset
+      </button>
+    </div>
+  </div>
+
+  <div class="mt-4">
+    <div class="btn-group" role="group">
+      <button class="btn btn-success" onclick="onSaveSlot()">
+        Save
+      </button>
+      <button class="btn btn-success" onclick="onLoadSlot()">
+        Load
+      </button>
+      <button class="btn btn-warning" onclick="onDeleteSlot()">
+        Delete
+      </button>
+    </div>
+  </div>
+
+  <div class="mt-4">
+    <select size="8" class="form-control" id="slotList">
+    </select>
+  </div>
 </div>
-
-<div class="form-group form-check">
-    <input class="form-check-input" id="removeDeployment" onchange="onAnyChange()" type="checkbox">
-    <label class="form-check-label" for="removeDeployment">Remove Deployment Map</label>
-</div>
-<div class="form-group form-check">
-    <input class="form-check-input" id="removeBorder" onchange="onAnyChange()" type="checkbox">
-    <label class="form-check-label" for="removeBorder">Remove border to add bleed area for printing</label>
-</div>
-
-<div class="mt-4">
-    <button type="submit" class="btn btn-success" id="saveCanvasButton" onclick="saveCardAsImage()">
-        Save card as image
-    </button>
-</div>
-
-<div class="mt-4">
-    <button type="submit" class="btn btn-success" id="saveButton" onclick="onSaveClicked()">
-        Save card as file
-    </button>
-</div>
-
-<div class="mt-4">
-    <label for="loadbutton">Load card file</label>
-    <input class="form-control-file" id="loadbutton" oninput="fileChange(this.files[0])" type="file">
-</div>
-
-<div class="mt-4">
-    <button type="submit" class="btn btn-success" id="clearCacheButton" onclick="onClearCache()">
-        Reset all
-    </button>
-    <br><hr>
-</div>
-
-
-<div class="mt-4">
-
-</div>
-
-
-<br>
-<br>
-<br>
-<br>
-<br>
-<br>

--- a/_includes/missions/section-actions.html
+++ b/_includes/missions/section-actions.html
@@ -26,22 +26,30 @@
       </div>
     </div>
 
-    <div class="mt-4">
-      <div class="btn-group" role="group">
-        <button class="btn btn-success" onclick="onSaveSlot()">
-          Save
-        </button>
-        <button class="btn btn-success" onclick="onLoadSlot()">
-          Load
-        </button>
-        <button class="btn btn-warning" onclick="onDeleteSlot()">
-          Delete
-        </button>
+    <div class="mt-4 row">
+      <div class="col-sm-6">
+        <div class="btn-group" role="group">
+          <input class="form-control" type="text" id="saveName" name="saveName" value="">
+          <button class="btn btn-success" onclick="onSaveSlot()">
+            Save
+          </button>
+        </div>
+      </div>
+
+      <div class="col-sm-6">
+        <div class="btn-group" role="group">
+          <button class="btn btn-success" onclick="onLoadSlot()">
+            Load
+          </button>
+          <button class="btn btn-warning" onclick="onDeleteSlot()">
+            Delete
+          </button>
+        </div>
       </div>
     </div>
 
     <div class="mt-4">
-      <select size="8" class="form-control" id="slotList">
+      <select size="8" class="form-control" id="slotList" oninput="onSlotListChange()">
       </select>
     </div>
   </div>

--- a/_includes/missions/section-background.html
+++ b/_includes/missions/section-background.html
@@ -36,7 +36,17 @@
                   </select>
                 </div>
               </div>
-            
+
+            <div class="form-check">
+                <input class="form-check-input" id="removeDeployment" onchange="onAnyChange()" type="checkbox">
+                <label class="form-check-label" for="removeDeployment">Remove Deployment Map</label>
+            </div>
+
+            <div class="form-check">
+                <input class="form-check-input" id="removeBorder" onchange="onAnyChange()" type="checkbox">
+                <label class="form-check-label" for="removeBorder">Remove border to add bleed area for printing</label>
+            </div>
+
               <div style="display: none;">
             <div class="row">
                 <div class="form-check form-check-inline">
@@ -158,27 +168,27 @@
                         Custom Background</button>
                 </h2>
             </div>
-        
+
             <div class="collapse" id="customBackgroundCollapse">
                 <div class="card-body">
-        
+
                     <div class="form-group">
                         <label for="customBackgroundSelect">Load image</label>
                         <input class="form-control-file" id="customBackgroundSelect" oninput="onCustomBackgroundUpload()" type="file">
                     </div>
-        
+
                     <input type="hidden" id="customBackgroundUrl" name="customBackgroundUrl" value="">
-        
+
                     <div class="form-group">
                         <label for="customBackgroundOffsetX">X offset (&#8596;)</label>
                         <input class="form-control" id="customBackgroundOffsetX" oninput="onAnyChange()" type="number" value="0" />
                     </div>
-        
+
                     <div class="form-group">
                         <label for="customBackgroundOffsetY">Y offset (&#8597;)</label>
                         <input class="form-control" id="customBackgroundOffsetY" oninput="onAnyChange()" type="number" value="0" />
                     </div>
-        
+
                     <div class="form-group">
                         <label for="customBackgroundScalePercent">Scale (%)</label>
                         <input class="form-control" id="customBackgroundScalePercent" min="0" max="300" oninput="onAnyChange()"

--- a/_includes/missions/section-characteristics.html
+++ b/_includes/missions/section-characteristics.html
@@ -13,7 +13,7 @@
             <div class="form-group">
                 <label for="missionName">Mission Name</label>
                 <input class="form-control" type="text" id="missionName" name="missionName" value=" "
-                    oninput="onAnyChange()">
+                    oninput="onMissionNameChange()">
             </div>
             <div class="form-group">
                 <label for="missionType">Mission Type</label>
@@ -37,4 +37,3 @@
             </div>
         </div>
     </div>
-    

--- a/_includes/missions/section-deployment.html
+++ b/_includes/missions/section-deployment.html
@@ -87,7 +87,7 @@
             <div class="form-group row">
                 <label for="redHammerRenderMode" class="col-sm-6 col-form-label">Hammer render mode</label>
                 <div class="col-sm-3">
-                  <select class="form-select" id="redHammerRenderMode" name="redHammerRenderMode" data-clear-on-load="false" onchange="onAnyChange()">
+                  <select class="form-select" id="redHammerRenderMode" name="redHammerRenderMode" onchange="onAnyChange()">
                     <option value="edge">From Edges</option>
                     <option value="centre">From Centre</option>
                     <option value="short">Shortest Path</option>
@@ -98,7 +98,7 @@
             <div class="form-group row">
                 <label for="redDaggerRenderMode" class="col-sm-6 col-form-label">Dagger render mode</label>
                 <div class="col-sm-3">
-                  <select class="form-select" id="redDaggerRenderMode" name="redDaggerRenderMode" data-clear-on-load="false" onchange="onAnyChange()">
+                  <select class="form-select" id="redDaggerRenderMode" name="redDaggerRenderMode" onchange="onAnyChange()">
                     <option value="edge">From Edges</option>
                     <option value="centre">From Centre</option>
                     <option value="short">Shortest Path</option>
@@ -109,7 +109,7 @@
             <div class="form-group row">
                 <label for="redShieldRenderMode" class="col-sm-6 col-form-label">Shield render mode</label>
                 <div class="col-sm-3">
-                  <select class="form-select" id="redShieldRenderMode" name="redShieldRenderMode" data-clear-on-load="false" onchange="onAnyChange()">
+                  <select class="form-select" id="redShieldRenderMode" name="redShieldRenderMode" onchange="onAnyChange()">
                     <option value="edge">From Edges</option>
                     <option value="centre">From Centre</option>
                     <option value="short">Shortest Path</option>
@@ -211,7 +211,7 @@
             <div class="form-group row">
                 <label for="blueHammerRenderMode" class="col-sm-6 col-form-label">Hammer render mode</label>
                 <div class="col-sm-3">
-                  <select class="form-select" id="blueHammerRenderMode" name="blueHammerRenderMode" data-clear-on-load="false" onchange="onAnyChange()">
+                  <select class="form-select" id="blueHammerRenderMode" name="blueHammerRenderMode" onchange="onAnyChange()">
                     <option value="edge">From Edges</option>
                     <option value="centre">From Centre</option>
                     <option value="short">Shortest Path</option>
@@ -222,7 +222,7 @@
             <div class="form-group row">
                 <label for="blueDaggerRenderMode" class="col-sm-6 col-form-label">Dagger render mode</label>
                 <div class="col-sm-3">
-                  <select class="form-select" id="blueDaggerRenderMode" name="blueDaggerRenderMode" data-clear-on-load="false" onchange="onAnyChange()">
+                  <select class="form-select" id="blueDaggerRenderMode" name="blueDaggerRenderMode" onchange="onAnyChange()">
                     <option value="edge">From Edges</option>
                     <option value="centre">From Centre</option>
                     <option value="short">Shortest Path</option>
@@ -233,7 +233,7 @@
             <div class="form-group row">
                 <label for="blueShieldRenderMode" class="col-sm-6 col-form-label">Shield render mode</label>
                 <div class="col-sm-3">
-                  <select class="form-select" id="blueShieldRenderMode" name="blueShieldRenderMode" data-clear-on-load="false" onchange="onAnyChange()">
+                  <select class="form-select" id="blueShieldRenderMode" name="blueShieldRenderMode" onchange="onAnyChange()">
                     <option value="edge">From Edges</option>
                     <option value="centre">From Centre</option>
                     <option value="short">Shortest Path</option>

--- a/_includes/missions/section-objectives.html
+++ b/_includes/missions/section-objectives.html
@@ -142,7 +142,7 @@
             <div class="form-group row">
                 <label for="objective1RenderMode" class="col-sm-6 col-form-label">Objective 1 render mode</label>
                 <div class="col-sm-3">
-                  <select class="form-select" id="objective1RenderMode" name="objective1RenderMode" data-clear-on-load="false" onchange="onAnyChange()">
+                  <select class="form-select" id="objective1RenderMode" name="objective1RenderMode" onchange="onAnyChange()">
                     <option value="edge">From Edges</option>
                     <option value="centre">From Centre</option>
                     <option value="short">Shortest Path</option>
@@ -153,7 +153,7 @@
             <div class="form-group row">
                 <label for="objective2RenderMode" class="col-sm-6 col-form-label">Objective 2 render mode</label>
                 <div class="col-sm-3">
-                  <select class="form-select" id="objective2RenderMode" name="objective2RenderMode" data-clear-on-load="false" onchange="onAnyChange()">
+                  <select class="form-select" id="objective2RenderMode" name="objective2RenderMode" onchange="onAnyChange()">
                     <option value="edge">From Edges</option>
                     <option value="centre">From Centre</option>
                     <option value="short">Shortest Path</option>
@@ -164,7 +164,7 @@
             <div class="form-group row">
                 <label for="objective3RenderMode" class="col-sm-6 col-form-label">Objective 3 render mode</label>
                 <div class="col-sm-3">
-                  <select class="form-select" id="objective3RenderMode" name="objective3RenderMode" data-clear-on-load="false" onchange="onAnyChange()">
+                  <select class="form-select" id="objective3RenderMode" name="objective3RenderMode" onchange="onAnyChange()">
                     <option value="edge">From Edges</option>
                     <option value="centre">From Centre</option>
                     <option value="short">Shortest Path</option>
@@ -175,7 +175,7 @@
             <div class="form-group row">
                 <label for="objective4RenderMode" class="col-sm-6 col-form-label">Objective 4 render mode</label>
                 <div class="col-sm-3">
-                  <select class="form-select" id="objective4RenderMode" name="objective4RenderMode" data-clear-on-load="false" onchange="onAnyChange()">
+                  <select class="form-select" id="objective4RenderMode" name="objective4RenderMode" onchange="onAnyChange()">
                     <option value="edge">From Edges</option>
                     <option value="centre">From Centre</option>
                     <option value="short">Shortest Path</option>
@@ -186,7 +186,7 @@
             <div class="form-group row">
                 <label for="objective5RenderMode" class="col-sm-6 col-form-label">Objective 5 render mode</label>
                 <div class="col-sm-3">
-                  <select class="form-select" id="objective5RenderMode" name="objective5RenderMode" data-clear-on-load="false" onchange="onAnyChange()">
+                  <select class="form-select" id="objective5RenderMode" name="objective5RenderMode" onchange="onAnyChange()">
                     <option value="edge">From Edges</option>
                     <option value="centre">From Centre</option>
                     <option value="short">Shortest Path</option>
@@ -197,7 +197,7 @@
             <div class="form-group row">
                 <label for="objective6RenderMode" class="col-sm-6 col-form-label">Objective 6 render mode</label>
                 <div class="col-sm-3">
-                  <select class="form-select" id="objective6RenderMode" name="objective6RenderMode" data-clear-on-load="false" onchange="onAnyChange()">
+                  <select class="form-select" id="objective6RenderMode" name="objective6RenderMode" onchange="onAnyChange()">
                     <option value="edge">From Edges</option>
                     <option value="centre">From Centre</option>
                     <option value="short">Shortest Path</option>

--- a/assets/js/missions.js
+++ b/assets/js/missions.js
@@ -492,19 +492,19 @@ function defaultmissionData() {
   data.blueHammerYValue = 17;
   data.blueHammerLine = false;
   data.blueHammerTurn = 1;
-  data.blueHammerRenderMode = 'edge';
+  data.blueHammerRenderMode = 'short';
 
   data.blueShieldXValue = 15;
   data.blueShieldYValue = 15;
   data.blueShieldLine = false;
   data.blueShieldTurn = 1;
-  data.blueShieldRenderMode = 'edge';
+  data.blueShieldRenderMode = 'short';
 
   data.blueDaggerXValue = 6;
   data.blueDaggerYValue = 17;
   data.blueDaggerLine = false;
   data.blueDaggerTurn = 1;
-  data.blueDaggerRenderMode = 'edge';
+  data.blueDaggerRenderMode = 'short';
 
   data.removeBlueDeployment = false;
 
@@ -512,19 +512,19 @@ function defaultmissionData() {
   data.redHammerYValue = 5;
   data.redHammerLine = false;
   data.redHammerTurn = 1;
-  data.redHammerRenderMode = 'edge';
+  data.redHammerRenderMode = 'short';
 
   data.redShieldXValue = 15;
   data.redShieldYValue = 7;
   data.redShieldLine = false;
   data.redShieldTurn = 1;
-  data.redShieldRenderMode = 'edge';
+  data.redShieldRenderMode = 'short';
 
   data.redDaggerXValue = 6
   data.redDaggerYValue = 5;
   data.redDaggerLine = false;
   data.redDaggerTurn = 1;
-  data.redDaggerRenderMode = 'edge';
+  data.redDaggerRenderMode = 'short';
 
   data.removeRedDeployment = false;
 

--- a/assets/js/missions.js
+++ b/assets/js/missions.js
@@ -335,7 +335,6 @@ function readControls() {
 }
 
 function render(missionData) {
-  console.log(missionData);
   if (missionData.customBackgroundUrl) {
     renderCustomBackground(missionData);
   } else {
@@ -474,7 +473,7 @@ async function writeControls(data) {
   render(data);
 }
 
-function defaultmissionData() {
+function defaultMissionData() {
   let data = new Object;
   data.name = "Warcry_Mission_Card";
   data.imageUrl = null;
@@ -554,66 +553,32 @@ function defaultmissionData() {
   data.white = false;
 
   data.textValue = "";
-console.log(data);
   return data;
 }
 
-function savemissionDataMap(newMap) {
-  window.localStorage.setItem("missionDataMap", JSON.stringify(newMap));
+function writeMissionData(data) {
+  window.localStorage.setItem("missionData", JSON.stringify(data));
 }
 
-function loadmissionDataMap() {
-  let storage = window.localStorage.getItem("missionDataMap");
-  if (storage != null) {
-    return JSON.parse(storage);
-  }
-  // Set up the map.
-  let map = new Object;
-  map["Warcry_Mission_Card"] = defaultmissionData();
-  savemissionDataMap(map);
-  return map;
-}
-
-function loadLatestmissionData() {
-  let latestFighterName = window.localStorage.getItem("latestFighterName");
-  if (latestFighterName == null) {
-    latestFighterName = "Warcry_Mission_Card";
-  }
-
-  let data = loadmissionData(latestFighterName);
-
-  if (data) {
-    console.log("Loaded data:");
-    console.log(data);
-  } else {
-    console.log("Failed to load data - loading default");
-    data = defaultCardData();
-  }
-
-  return data;
-}
-
-function saveLatestmissionData() {
-  let missionData = readControls();
-  if (!missionData.name) {
+function readMissionData() {
+  let storage = window.localStorage.getItem("missionData");
+  if (storage == null) {
     return;
   }
-
-  window.localStorage.setItem("latestFighterName", missionData.name);
-  //savemissionData(missionData);
+  return JSON.parse(storage);
 }
 
-function loadmissionData(missionDataName) {
-  if (!missionDataName) {
-    return null;
-  }
+function saveMissionData() {
+  writeMissionData(readControls());
+}
 
-  let map = loadmissionDataMap();
-  if (map[missionDataName]) {
-    return map[missionDataName];
+function loadMissionDataOrDefault() {
+  let data = readMissionData();
+  if (data == null) {
+    writeControls(defaultMissionData());
+  } else {
+    writeControls(data);
   }
-
-  return null;
 }
 
 function getBase64Image(img) {
@@ -662,7 +627,7 @@ function getLatestmissionDataName() {
 function onAnyChange() {
   let missionData = readControls();
   render(missionData);
-  saveLatestmissionData();
+  saveMissionData();
 }
 
 function onFighterImageUpload() {
@@ -670,7 +635,7 @@ function onFighterImageUpload() {
   setModelImage(image);
   let missionData = readControls();
   render(missionData);
-  saveLatestmissionData();
+  saveMissionData();
 }
 
 function onCopyFromRed() {
@@ -701,27 +666,7 @@ function onClearCache() {
 }
 
 function onResetToDefault() {
-  let missionData = defaultmissionData();
-  writeControls(missionData);
-}
-
-function refreshSaveSlots() {
-  // Remove all
-  $('select:not([data-clear-on-load="false"])').children('option').remove();
-
-  let missionDataName = readControls().name;
-
-  let map = loadmissionDataMap();
-
-  for (let [key, value] of Object.entries(map)) {
-    let selected = false;
-    if (missionDataName &&
-        key == missionDataName) {
-      selected = true;
-    }
-    let newOption = new Option(key, key, selected, selected);
-    $('#saveSlotsSelect').append(newOption);
-  }
+  writeControls(defaultMissionData());
 }
 
 async function onSaveClicked() {
@@ -856,7 +801,7 @@ function onCustomBackgroundUpload() {
   setCustomBackground(image);
   let missionData = readControls();
   render(missionData);
-  saveLatestmissionData();
+  saveMissionData();
 }
 
 function getCustomBackgroundUrl() {
@@ -1701,7 +1646,5 @@ function randomDeployment() {
 }
 
 window.onload = function() {
-  let missionData = loadLatestmissionData();
-  writeControls(missionData);
-  refreshSaveSlots();
+  loadMissionDataOrDefault();
 };

--- a/assets/js/missions.js
+++ b/assets/js/missions.js
@@ -193,14 +193,6 @@ function drawMissionType(value) {
   });
 }
 
-function getLabel(element) {
-  return $(element).prop("labels")[0];
-}
-
-function getImage(element) {
-  return $(element).find("img")[0];
-}
-
 function drawImage(scaledPosition, scaledSize, image) {
   if (image != null) {
     if (image.complete) {
@@ -239,16 +231,6 @@ function drawModel(imageUrl, imageProps) {
     };
     image.src = imageUrl;
   }
-}
-
-function getName() {
-  //let textInput = $("#saveNameInput")[0];
-  return "Warcry_Mission_Card";
-}
-
-function setName(name) {
-  //let textInput = $("#saveNameInput")[0];
-  //textInput.value = name;
 }
 
 function setModelImage(image) {
@@ -296,7 +278,6 @@ function getDefaultModelImageProperties() {
 
 function readControls() {
   let data = new Object;
-  data.name = getName();
   data.imageUrl = getFighterImageUrl();
   data.imageProperties = getModelImageProperties();
   data.customBackgroundUrl = getCustomBackgroundUrl();
@@ -475,7 +456,6 @@ async function writeControls(data) {
 
 function defaultMissionData() {
   let data = new Object;
-  data.name = "Warcry_Mission_Card";
   data.imageUrl = null;
   data.imageProperties = getDefaultModelImageProperties();
   data.base64Image = null;
@@ -692,7 +672,7 @@ function onAnyChange() {
 }
 
 function onFighterImageUpload() {
-  image = getModelImage();
+  let image = getModelImage();
   setModelImage(image);
   onAnyChange();
 }

--- a/assets/js/missions.js
+++ b/assets/js/missions.js
@@ -417,8 +417,10 @@ async function writeControls(data) {
   setModelImageProperties(data.imageProperties);
   setCustomBackground(data.customBackgroundUrl);
   setCustomBackgroundProperties(data.customBackgroundProperties);
-  $("#missionName")[0].value = data.missionName;
-  $("#missionType")[0].value = data.missionType;
+  document.getElementById("missionName").value = data.missionName;
+  document.getElementById("missionType").value = data.missionType;
+
+  document.getElementById("saveName").value = data.missionName;
 
   // check and uncheck if needed
 
@@ -452,6 +454,18 @@ async function writeControls(data) {
 
   // render the updated info
   render(data);
+}
+
+function onMissionNameChange() {
+  document.getElementById("saveName").value = document.getElementById("missionName").value;
+  onAnyChange();
+}
+
+function onSlotListChange() {
+  let selectedValue = document.getElementById("slotList").value;
+  if (selectedValue) {
+    document.getElementById("saveName").value = selectedValue;
+  }
 }
 
 function defaultMissionData() {
@@ -570,12 +584,13 @@ function enumerateMissionSlots(includeDefault = false) {
 }
 
 function onSaveSlot() {
-  let data = readControls();
-  if (!data.missionName) {
-    alert("Error: Card has no name");
+  let name = document.getElementById("saveName").value;
+  if (!name) {
+    alert("Error: No name");
     return;
   }
-  writeMissionData(data.missionName, data);
+  let data = readControls();
+  writeMissionData(name, data);
   updateSlotList();
 }
 
@@ -592,6 +607,7 @@ function onLoadSlot() {
   }
 
   writeControls(data);
+  document.getElementById("saveName").value = selectedName;
 }
 
 function onDeleteSlot() {

--- a/assets/js/missions.js
+++ b/assets/js/missions.js
@@ -694,9 +694,7 @@ function onAnyChange() {
 function onFighterImageUpload() {
   image = getModelImage();
   setModelImage(image);
-  let missionData = readControls();
-  render(missionData);
-  saveMissionData();
+  onAnyChange();
 }
 
 function onCopyFromRed() {
@@ -855,9 +853,7 @@ function setCustomBackground(image) {
 function onCustomBackgroundUpload() {
   image = getCustomBackground();
   setCustomBackground(image);
-  let missionData = readControls();
-  render(missionData);
-  saveMissionData();
+  onAnyChange();
 }
 
 function getCustomBackgroundUrl() {

--- a/assets/js/missions.js
+++ b/assets/js/missions.js
@@ -592,6 +592,7 @@ function onSaveSlot() {
   let data = readControls();
   writeMissionData(name, data);
   updateSlotList();
+  document.getElementById("slotList").value = name;
 }
 
 function onLoadSlot() {


### PR DESCRIPTION
Rewrote load/save logic.

- Autosaves work on any change + restores on page load.
- Allow explicit save to save-slot
- Moved controls that had little to do with load/save up under "Background"

I'm not sure why there even is a "Remove Deployment Map" option? Why would anyone ever need that? Is it something that was used for debugging?