### PR TITLE
Various load and reset errors

### DIFF
--- a/assets/js/abilities.js
+++ b/assets/js/abilities.js
@@ -138,7 +138,7 @@ function drawAbility(id, pixelPosition) {
             var title = '[Quad] ' + name + ': ';
         }
     }
-    
+
     // idea here is to check the number of runemarks being used per row
     // then adjust the text size to account.
     // would need to check cardData.tagRunemarksOne
@@ -232,11 +232,11 @@ function calculateFontSizeToFit(maxWidth, startingFontSize, minFontSize, text) {
     do {
         context.font = fontSize + 'px Georgia, serif';
         const textWidth = context.measureText(text).width;
-        
+
         if (textWidth <= maxWidth) {
             break; // If the text fits, exit the loop
         }
-        
+
         fontSize--; // Reduce the font size if text width is greater than maxWidth
     } while (fontSize > minFontSize);
 
@@ -587,7 +587,7 @@ function drawTagRunemark(index, runemark, row) {
         if (tripleCheck) {
             positions = positions.map(({x, y}) => ({x: x - 90, y}));
         } else {
-            positions = positions.map(({x, y}) => ({x: x - 90, y}));   
+            positions = positions.map(({x, y}) => ({x: x - 90, y}));
         }
     }
 
@@ -614,7 +614,7 @@ function drawTagRunemark(index, runemark, row) {
     var image = new Image();
     image.onload = function () {
         drawImage(position, size, image);
-    
+
         // write the runemark name underneath
         if (document.getElementById('runemark-names').checked){
             value = runemark.slice(25);
@@ -622,7 +622,7 @@ function drawTagRunemark(index, runemark, row) {
             if (value == "leader"){
                 value = "hero";
             }
-            if (tripleCheck) { 
+            if (tripleCheck) {
                 if (document.getElementById('bg-09').checked){
                     getContext().font = '22px schoensperger';
                 } else {
@@ -634,11 +634,11 @@ function drawTagRunemark(index, runemark, row) {
                 } else {
                     getContext().font = '20px rodchenkoctt';
                 }
-            }  
+            }
             getContext().fillStyle = 'white';
             getContext().textAlign = "center";
             getContext().textBaseline = "middle";
-            if (tripleCheck) { 
+            if (tripleCheck) {
                 x_value = positions[index].x + 100/2;
                 y_value = positions[index].y + 110;
             } else {
@@ -779,7 +779,7 @@ function getTagRunemarkId(runemark, ability) {
     // the id starts with the ability number in text form, one to seven lower case
     var result = ability;
     // the second part is One to Twentyfive each starting with a capital
-    // each runemark is in order, so we can get the second part based on 
+    // each runemark is in order, so we can get the second part based on
     if (runemark == "runemarks/black/fighters-agile.svg") {
         result = result + "One"
     }
@@ -1000,7 +1000,8 @@ function onTagRunemarkFileSelect() {
 }
 
 function onClearCache() {
-    window.localStorage.clear();
+    window.localStorage.removeItem("cardDataMap");
+    window.localStorage.removeItem("latestAbilitiesName");
     location.reload();
     return false;
 }
@@ -1608,14 +1609,14 @@ window.onload = function () {
     getAbilityList()
         // log response or catch error of fetch promise
         .then((data) => updateAbilityListDropdown(data))
-    
+
         var queryString = window.location.search;
         var urlParams = new URLSearchParams(queryString);
-        
+
         var id = urlParams.get('id');
         var ability = urlParams.get('ability');
         var warband = urlParams.get('warband');
-        
+
         if (id && id.trim() !== '') {
             loadAbilityById(id);
         } else if (ability && ability.trim() !== '' && validateInput(warband)) {
@@ -1696,7 +1697,7 @@ function updateAbilityListDropdown(data){
     const sortedData = data.sort((a, b) => {
         if (a.warband === b.warband) {
           const costOrder = { reaction: 1, double: 2, triple: 3, quad: 4 };
-      
+
           if (a.cost in costOrder && b.cost in costOrder) {
             return costOrder[a.cost] - costOrder[b.cost];
           } else if (a.cost in costOrder) {
@@ -1705,10 +1706,10 @@ function updateAbilityListDropdown(data){
             return 1;
           }
         }
-      
+
         return a.warband.localeCompare(b.warband);
       });
-      
+
 
     for (let i = 1; i <= 7; i++) {
       $.each(sortedData, function(index, option) {
@@ -1748,7 +1749,7 @@ async function getAbilityList(){
       }).sort((a, b) => {
         if (a.warband === b.warband) {
           const costOrder = { Reaction: 1, Double: 2, Triple: 3, Quad: 4 };
-      
+
           if (a.cost in costOrder && b.cost in costOrder) {
             return costOrder[a.cost] - costOrder[b.cost];
           } else if (a.cost in costOrder) {
@@ -1757,28 +1758,28 @@ async function getAbilityList(){
             return 1;
           }
         }
-      
+
         return a.warband.localeCompare(b.warband);
       });
-      
-          
+
+
     return sortedData;
 }
 
 function saveAbilityFromList(ability, abilityNumber){
-    
+
     var data = readControls();
     // change from just runemark name to full path
 
     runemarks =  getRunemarks(ability.runemarks);
-    
+
     dynamicAbilityName = "ability" + abilityNumber + "Name";
     dynamicAbilityText = "ability" + abilityNumber + "Text";
     dynamicAbilityReactionChecked = "ability" + abilityNumber + "ReactionChecked";
     dynamicAbilityDoubleChecked = "ability" + abilityNumber + "DoubleChecked";
     dynamicAbilityTripleChecked = "ability" + abilityNumber + "TripleChecked";
     dynamicAbilityQuadChecked = "ability" + abilityNumber + "QuadChecked";
-    
+
     data[dynamicAbilityName] = ability.name;
     data[dynamicAbilityText] = ability.description;
     data[dynamicAbilityReactionChecked] = false;
@@ -1837,7 +1838,7 @@ function getRunemarks(runemarks){
     if (runemarks.includes("elite")){
         tagRunemarks.push('runemarks/black/fighters-elite.svg');
     }
-    if (runemarks.includes("icon bearer")){ 
+    if (runemarks.includes("icon bearer")){
         tagRunemarks.push('runemarks/black/fighters-icon-bearer.svg');
     }
     if (runemarks.includes("mount")){

--- a/assets/js/fighters.js
+++ b/assets/js/fighters.js
@@ -1030,7 +1030,7 @@ function loadLatestFighterData() {
     }
     else {
         console.log("Failed to load data - loading default");
-        data = defaultCardData();
+        data = defaultFighterData();
     }
 
     return data;

--- a/assets/js/fighters.js
+++ b/assets/js/fighters.js
@@ -2,7 +2,7 @@ const writeValue = function(ctx, value, position) {
     if (!ctx || typeof ctx.fillText !== 'function') {
       throw new Error('Invalid canvas context');
     }
-  
+
     const canvas = getCanvas();
     const backgroundImage = getBackgroundImage();
     const scale = getScalingFactor(canvas, backgroundImage);
@@ -10,7 +10,7 @@ const writeValue = function(ctx, value, position) {
       x: position.x / scale.x,
       y: position.y / scale.y
     };
-  
+
     ctx.scale(scale.x, scale.y);
     ctx.fillText(value, scaledPosition.x, scaledPosition.y);
   };
@@ -147,8 +147,8 @@ drawFighterName = function (value) {
         getContext().font = '44px schoensperger';
     } else {
         getContext().font = '44px rodchenkoctt';
-    }    
-    
+    }
+
     getContext().fillStyle = 'white';
     getContext().textAlign = "center";
     getContext().textBaseline = "middle";
@@ -161,37 +161,37 @@ drawFighterName = function (value) {
 
     getContext().fillStyle = 'black';
     writeScaled(value, { x: startX, y: startY });
-    
+
 }
 
 function scaleFontSizeToFit(text, maxWidth, startingFontSize) {
     const canvas = document.createElement('canvas');
     const context = canvas.getContext('2d');
     let fontSize = startingFontSize;
-  
+
     let textWidth; // Define textWidth here
-  
+
     do {
       context.font = fontSize + 'px sans-serif'; // Change the font family as needed
       textWidth = context.measureText(text).width; // Calculate textWidth
       fontSize--;
     } while (textWidth > maxWidth && fontSize > 0);
-  
+
     return fontSize;
   }
-  
+
   function drawFighterName2(value) {
     const startX = 850;
     const startY = 725;
     maxWidth = 450;
     const font = scaleFontSizeToFit(value, maxWidth, 44);
-  
+
     if (document.getElementById('background-list').value === 'bg-13') {
       getContext().font = font + 'px schoensperger';
     } else {
       getContext().font = font + 'px rodchenkoctt';
     }
-  
+
     getContext().fillStyle = 'white';
     getContext().textAlign = 'center';
     getContext().textBaseline = 'middle';
@@ -201,11 +201,11 @@ function scaleFontSizeToFit(text, maxWidth, startingFontSize) {
     writeScaled(value, { x: startX - 2, y: startY });
     writeScaled(value, { x: startX, y: startY - 2 });
     writeScaled(value, { x: startX - 2, y: startY - 2 });
-  
+
     getContext().fillStyle = 'black';
     writeScaled(value, { x: startX, y: startY });
-  }  
-  
+  }
+
 
 drawToughness = function (value) {
     getContext().font = "60px rodchenkoctt";
@@ -745,7 +745,7 @@ const render = function(fighterData) {
       renderDefaultBackground(fighterData);
     }
   };
-  
+
 const renderCustomBackground = function(fighterData) {
     const backgroundImage = new Image();
     const removeTextAndFrame = document.getElementById("removeTextAndFrame").checked;
@@ -769,11 +769,11 @@ const renderCustomBackground = function(fighterData) {
             }
         };
         renderFighterImage(fighterData);
-        
+
     };
     backgroundImage.src = fighterData.customBackgroundUrl;
 };
-  
+
 const renderDefaultBackground = function(fighterData) {
     const removeTextAndFrame = document.getElementById("removeTextAndFrame").checked;
     getContext().drawImage(getBackgroundImage(), 0, 0, getCanvas().width, getCanvas().height);
@@ -783,7 +783,7 @@ const renderDefaultBackground = function(fighterData) {
     drawBorder();
     renderFighterImage(fighterData);
 };
-  
+
 const renderFighterImage = function(fighterData) {
     const removeTextAndFrame = document.getElementById("removeTextAndFrame").checked;
     if (fighterData.imageUrl) {
@@ -814,7 +814,7 @@ const renderFighterImage = function(fighterData) {
     }
 };
 
-  
+
 
 function drawOverlayTexts(fighterData) {
     const {
@@ -831,28 +831,28 @@ function drawOverlayTexts(fighterData) {
       weapon2,
       tagRunemarks,
     } = fighterData;
-  
+
     // Set default values for the checkboxes
     const subfactionCheckbox = document.getElementById('subfaction-runemarks/none/blank.gif');
     const deploymentCheckbox = document.getElementById('checkbox-assets/img/blank2.gif');
-  
+
     const showSubfactionRunemark = subfactionCheckbox.checked;
     const showDeploymentRunemark = deploymentCheckbox.checked;
-  
+
     // These are the texts to overlay
     drawFighterName(fighterName);
     drawFighterName2(fighterName2);
     drawFactionRunemark(factionRunemark);
     drawBorder();
-  
+
     // Draw subfaction runemark if enabled
-    if (!(document.getElementById('subfaction-runemarks/none/blank.gif').checked) 
+    if (!(document.getElementById('subfaction-runemarks/none/blank.gif').checked)
         && fighterData.subfactionRunemark != null
         && !document.getElementById("bladebornRunemark").checked
         ) {
         drawSubfactionRunemark(subfactionRunemark);
     }
-  
+
     // Draw deployment runemark if enabled
     if (!(document.getElementById('checkbox-assets/img/blank2.gif').checked) && fighterData.deploymentRunemark != null) {
         drawDeploymentRunemark(fighterData.deploymentRunemark);
@@ -861,7 +861,7 @@ function drawOverlayTexts(fighterData) {
     drawWounds(wounds);
     drawToughness(toughness);
     drawPointCost(pointCost);
-  
+
     // Determine which weapon(s) to draw and their positions
     if (weapon1.enabled && weapon2.enabled) {
       drawWeapon(weapon2, { x: 68, y: 520 }); // Default was x:29, y:397
@@ -871,8 +871,8 @@ function drawOverlayTexts(fighterData) {
     } else if (weapon2.enabled) {
       drawWeapon(weapon2, { x: 68, y: 550 }); // Default was x:29, y:463
     }
-  
-    if (!(document.getElementById('subfaction-runemarks/none/blank.gif').checked) 
+
+    if (!(document.getElementById('subfaction-runemarks/none/blank.gif').checked)
           && fighterData.subfactionRunemark != null
           && document.getElementById("bladebornRunemark").checked
           ) {
@@ -885,7 +885,7 @@ function drawOverlayTexts(fighterData) {
       drawTagRunemark(i, tagRunemarks[i]);
     }
   }
-  
+
 
 async function writeControls(fighterData) {
     //setName("Warcry_Fighter_Card"); // Always default, trying to move away from this
@@ -1103,8 +1103,6 @@ function getLatestFighterDataName() {
 }
 
 window.onload = function () {
-    //window.localStorage.clear();
-
     var fighterData = loadLatestFighterData();
     writeControls(fighterData);
     refreshSaveSlots();
@@ -1112,14 +1110,14 @@ window.onload = function () {
     getFighterList()
         // log response or catch error of fetch promise
         .then((data) => updateFighterListDropdown(data))
-    
+
         var queryString = window.location.search;
         var urlParams = new URLSearchParams(queryString);
-        
+
         var id = urlParams.get('id');
         var fighter = urlParams.get('fighter');
         var warband = urlParams.get('warband');
-        
+
         if (id && id.trim() !== '') {
             loadFighterById(id);
         } else if (fighter && fighter.trim() !== '' && validateInput(warband)) {
@@ -1270,7 +1268,9 @@ function addToImageCheckboxSelector(imgSrc, grid, bgColor) {
 }
 
 function onClearCache() {
-    window.localStorage.clear();
+    window.localStorage.removeItem("fighterDataMap");
+    window.localStorage.removeItem("latestFighterName");
+
     location.reload();
     return false;
 }
@@ -1314,17 +1314,17 @@ async function onSaveClicked() {
     //data.imageUrl = null;
 
     // need to be explicit due to sub arrays
-    var exportObj = JSON.stringify(data, ['name', 'imageUrl', 
-        'imageProperties', 'offsetX', 'offsetY', 'scalePercent', 
+    var exportObj = JSON.stringify(data, ['name', 'imageUrl',
+        'imageProperties', 'offsetX', 'offsetY', 'scalePercent',
         'factionRunemark', 'subfactionRunemark', 'deploymentRunemark', 'fighterName', 'fighterName2',
-        'toughness', 'wounds', 'move', 'pointCost', 'tagRunemarks', 
+        'toughness', 'wounds', 'move', 'pointCost', 'tagRunemarks',
         'weapon1', 'attacks', 'damageBase', 'damageCrit',
-        'enabled', 'rangeMax', 'rangeMin', 'runemark', 'strength', 
+        'enabled', 'rangeMax', 'rangeMin', 'runemark', 'strength',
         'weapon2', 'attacks', 'damageBase', 'damageCrit',
         'enabled', 'rangeMax', 'rangeMin', 'runemark', 'strength',
-        'bg01', 'bg02', 'bg03', 'bg04', 'bg05', 'bg06', 'bg07', 'bg08', 'bg09', 'bg10', 
+        'bg01', 'bg02', 'bg03', 'bg04', 'bg05', 'bg06', 'bg07', 'bg08', 'bg09', 'bg10',
         'bg11','bg12','bg13', 'bg14', 'bg15', 'bg16', 'bgselected',
-        'customBackgroundUrl', 'customBackgroundProperties','customBackgroundOffsetX', 
+        'customBackgroundUrl', 'customBackgroundProperties','customBackgroundOffsetX',
         'customBackgroundOffsetY', 'customBackgroundScalePercent',
         'base64CustomBackground', 'base64Image'], 4);
 
@@ -1338,7 +1338,7 @@ async function onSaveClicked() {
     } else {
         file_name = file_name + "_" + data.fighterName2.replace(/ /g, "_").trim() + ".json";
     }
-    
+
     downloadAnchorNode.setAttribute("download", file_name);
     document.body.appendChild(downloadAnchorNode); // required for firefox
     downloadAnchorNode.click();
@@ -1368,7 +1368,7 @@ $(document).ready(function () {
     ctx.beginPath();
     ctx.arc(95, 50, 40, 0, 2 * Math.PI);
     // ctx.stroke();
-    
+
 });
 
 async function readJSONFile(file) {
@@ -1420,7 +1420,7 @@ async function fileChange(file) {
 
 
         writeControls(json);
-        
+
     };
 
     readJSONFile(file).then(json =>
@@ -1488,7 +1488,7 @@ async function loadFighterById(id) {
       .then(data => {
         // Find the fighter with the matching id
         const fighter = data.find(f => f._id === id);
-        
+
         // Check if fighter is found
         if (fighter) {
           // Call saveFighterFromList with the fighter as input
@@ -1501,7 +1501,7 @@ async function loadFighterById(id) {
         console.log("Error loading fighters:", error);
       });
   }
-  
+
 
 async function loadFighterByName(name, warband) {
     let response = await fetch("https://krisling049.github.io/warcry_data/fighters.jsonn");
@@ -1517,7 +1517,7 @@ async function loadFighterByName(name, warband) {
         return fullName.toLowerCase().includes(name.toLowerCase());
       }
     });
-  
+
     if (filteredData.length == 1) {
       saveFighterFromList(filteredData[0]);
     } else if (filteredData.length > 1) {
@@ -1540,8 +1540,8 @@ async function loadFighterByName(name, warband) {
     }
     updateStats();
   }
-  
-  
+
+
 
 function saveFighterFromList(fighter){
 
@@ -1560,7 +1560,7 @@ function saveFighterFromList(fighter){
 
     fighterName = fighter.name;
     fighterName2 = " ";
-  
+
     if (fighter.name.length > 20) {
       const lastSpaceIndex = fighter.name.lastIndexOf(" ", 20);
       if (lastSpaceIndex !== -1) {
@@ -1623,7 +1623,7 @@ function saveFighterFromList(fighter){
 }
 
 function getFactionRunemark(warband){
-    if(warband == "Beasts of Chaos") {runemark = "runemarks/white/factions-chaos-beasts-of-chaos.svg"} 
+    if(warband == "Beasts of Chaos") {runemark = "runemarks/white/factions-chaos-beasts-of-chaos.svg"}
     else if(warband == "Chaos Legionnaires") {runemark = "runemarks/white/factions-chaos-chaos-legionnaires.svg";}
     else if(warband == "Corvus Cabal") {runemark = "runemarks/white/factions-chaos-corvus-cabal.svg";}
     else if(warband == "Cypher Lords") {runemark = "runemarks/white/factions-chaos-cypher-lords.svg";}
@@ -1690,11 +1690,11 @@ function getFactionRunemark(warband){
     else if(warband == "Cities of Sigmar: Castelite Hosts") {runemark = "runemarks/white/factions-order-cities-of-sigmar-castelite-hosts.svg";}
     else if(warband == "Cities of Sigmar: Dispossessed") {runemark = "runemarks/white/factions-order-cities-of-sigmar-dispossessed.svg";}
     else if(warband == "Cities of Sigmar: Darkling Covens") {runemark = "runemarks/white/factions-order-cities-of-sigmar-darkling-covens.svg";}
-    
+
     else { runemark = "runemarks/white/factions-chaos-everchosen.svg";}
     console.log(warband)
     console.log(runemark)
-    
+
     return runemark;
 }
 
@@ -1731,7 +1731,7 @@ function getRunemarks(runemarks){
     if (runemarks.includes("elite")){
         tagRunemarks.push('runemarks/black/fighters-elite.svg');
     }
-    if (runemarks.includes("icon bearer")){ 
+    if (runemarks.includes("icon bearer")){
         tagRunemarks.push('runemarks/black/fighters-icon-bearer.svg');
     }
     if (runemarks.includes("mount")){
@@ -1781,7 +1781,7 @@ function getRunemarks(runemarks){
 
 
 function getWeaponRunemark(weaponSymbol){
-    if(weaponSymbol == "axe") {runemark = "runemarks/black/weapons-axe.svg"} 
+    if(weaponSymbol == "axe") {runemark = "runemarks/black/weapons-axe.svg"}
     else if(weaponSymbol == "bident") {runemark = "runemarks/black/weapons-bident.svg";}
     else if(weaponSymbol == "blast") {runemark = "runemarks/black/weapons-blast.svg";}
     else if(weaponSymbol == "claws") {runemark = "runemarks/black/weapons-claws.svg";}
@@ -1962,13 +1962,13 @@ function calculateAverageDamage(attacks, strength, damage, crit, toughness) {
 function estimatePoints() {
     var fighterData = readControls();
     var adjustment = document.getElementById("adjustment").value;
-    var averageDamage1T4 = calculateAverageDamage(fighterData.weapon1.attacks, fighterData.weapon1.strength, 
+    var averageDamage1T4 = calculateAverageDamage(fighterData.weapon1.attacks, fighterData.weapon1.strength,
                                                 fighterData.weapon1.damageBase, fighterData.weapon1.damageCrit, 4);
-    var averageDamage2T4 = calculateAverageDamage(fighterData.weapon2.attacks, fighterData.weapon2.strength, 
+    var averageDamage2T4 = calculateAverageDamage(fighterData.weapon2.attacks, fighterData.weapon2.strength,
                                                 fighterData.weapon2.damageBase, fighterData.weapon2.damageCrit, 4);
 
     var pointsPerDamage = 25;
-    var pointsPerWound = 25/3;         
+    var pointsPerWound = 25/3;
 
     // To select the primary weapon we can't just do max damage, we need to adjust by range scaling.
     weapon1range_percentage = 0;
@@ -2020,7 +2020,7 @@ function estimatePoints() {
     basepoints = Math.round((points_for_wounds + points_for_damage)/2);
     // Calculate the adjustment percentage based on the difference from the baseline
     percentage = parseInt(adjustment);
-    
+
     if (fighterData.move > 4) {
         move_percentage = 5
         move_percentage +=  (fighterData.move - 4) * 5
@@ -2041,7 +2041,7 @@ function estimatePoints() {
     if(fighterData.tagRunemarks.includes("runemarks/black/fighters-fly.svg")){
         fly_percentage = 10;
     }
-    
+
     percentage += move_percentage;
     percentage += toughness_percentage;
     percentage += weaponrange_percentage;
@@ -2056,15 +2056,15 @@ function estimatePoints() {
     var resultText = `Estimated points: ${points}
 
         `;
-    var resultTextDetails = `Base ${basepoints} points with ${percentage}% adjustment: 
+    var resultTextDetails = `Base ${basepoints} points with ${percentage}% adjustment:
 
         Base:
         - Base from Wounds : ${Math.round(points_for_wounds)} pts
         - Base from Weapon1 : ${Math.round(averageDamage1T4 * pointsPerDamage)} pts
         - Base from Weapon2 : ${Math.round(averageDamage2T4 * pointsPerDamage)} pts
 
-        Adjustment:    
-        - Movement : ${move_percentage}%    
+        Adjustment:
+        - Movement : ${move_percentage}%
         - Toughness : ${toughness_percentage}%
         - Weapon range : ${weaponrange_percentage}%
         - Fly : ${fly_percentage}%

--- a/assets/js/objects.js
+++ b/assets/js/objects.js
@@ -384,11 +384,11 @@ function defaultCardData() {
 }
 
 function saveCardDataMap(newMap) {
-    window.localStorage.setItem("cardDataMap", JSON.stringify(newMap));
+    window.localStorage.setItem("cardObjectDataMap", JSON.stringify(newMap));
 }
 
 function loadCardDataMap() {
-    var storage = window.localStorage.getItem("cardDataMap");
+    var storage = window.localStorage.getItem("cardObjectDataMap");
     if (storage != null) {
         return JSON.parse(storage);
     }
@@ -515,7 +515,7 @@ function addToImageCheckboxSelector(imgSrc, grid, bgColor) {
 }
 
 function onClearCache() {
-    window.localStorage.removeItem("cardDataMap");
+    window.localStorage.removeItem("cardObjectDataMap");
     window.localStorage.removeItem("latestObjectName");
     location.reload();
     return false;

--- a/assets/js/objects.js
+++ b/assets/js/objects.js
@@ -64,7 +64,7 @@ getBackgroundImage = function () {
         return document.getElementById('warcry_object_mordheim');
     }
 
-    
+
 }
 
 drawBackground = function () {
@@ -128,7 +128,7 @@ drawObjectName = function (value) {
         getContext().font = font_size + 'px schoensperger';
     } else {
         getContext().font = font_size + 'px lithosblack';
-    }    
+    }
     getContext().fillStyle = colourBorder;
     writeScaled(value, { x: x_pos +2, y: y_pos+2 });
     writeScaled(value, { x: x_pos -2, y: y_pos-2 });
@@ -479,7 +479,6 @@ function getLatestCardDataName() {
 }
 
 window.onload = function () {
-    //window.localStorage.clear();
     var cardData = loadLatestCardData();
     writeControls(cardData);
     refreshSaveSlots();
@@ -516,7 +515,8 @@ function addToImageCheckboxSelector(imgSrc, grid, bgColor) {
 }
 
 function onClearCache() {
-    window.localStorage.clear();
+    window.localStorage.removeItem("cardDataMap");
+    window.localStorage.removeItem("latestObjectName");
     location.reload();
     return false;
 }


### PR DESCRIPTION
Fixes a couple of problems with load and save.

- `defaultFighterData` was renamed long ago, causing an error on load.
- Objects saved data into same slot as abilities
- Reset data would nuke data across all tabs/tools, rather than just the current.

Note that I did not fix the same error for missions.js, even though present. This is because it is already addressed in https://github.com/barrysheppard/warcry-card-creator/pull/11